### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,6 @@
 name: Deploying GSSAR
+permissions:
+  contents: read
 "on":
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/GSSAR/security/code-scanning/2](https://github.com/advanced-security/GSSAR/security/code-scanning/2)

To fix the issue, we need to add a `permissions:` key in the workflow file to restrict the GITHUB_TOKEN's access as tightly as possible. This can be done either globally (at the file root, applying to all jobs) or within each individual job (here, within `DeployStack`). Since there is only one job and the minimal permissions required for typical deploy/build workflows is `contents: read` (needed for actions/checkout and similar), we will add a `permissions:` block to limit access. Place the following YAML block:
```yaml
permissions:
  contents: read
```
directly under the workflow `name:` (line 1), above `"on":`.  
This is the least-privilege configuration for workflows needing only read access to repository contents; adjust further if more specific privileges (such as `pull-requests: write`) are required by your workflow steps in the future.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
